### PR TITLE
gobext: Don't force outdir subfolder if user specified outdir by cmd arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ CTestTestfile.cmake
 .vs
 .vscode
 CMakeSettings.json
+out

--- a/programs/gobext/main.cpp
+++ b/programs/gobext/main.cpp
@@ -115,7 +115,10 @@ int main(int argc, const char *argv[])
     {
         auto vfs = gobLoad(inputFile);
 
-        outdir /= inputFile.stem().string() + "_GOB";
+        if (outdir == "")
+        {
+            outdir /= inputFile.stem().string() + "_GOB";
+        }
         makePath(outdir);
 
         if(!extractGob(vfs, outdir, bVerboseOutput)) {


### PR DESCRIPTION
Creating a unique subfolder for extraction is useful for ordinary users that just want to extract the .GOB file. However, advanced users may wish to specify an exact output directory (for example, for the purposes of automating execution of Urgon via scripts).

This PR proposes a solution by creating a subfolder named according to the GOB file only if the user has not explicitly specified an output directory.

PS: I also modified .gitignore because building in Visual Studio 2022 via CMake integration builds into a folder named `out`, which should be ignored.